### PR TITLE
compile SCSS to CSS

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { app, BrowserWindow } from 'electron';
 import path from 'node:path';
 import pug from 'pug';
 import fs from 'fs'; 
+import * as sass from 'sass';
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (require('electron-squirrel-startup')) {
@@ -39,7 +40,18 @@ const createWindow = () => {
     const tempStylePath = path.join(tempDir, 'style.css');
 
     if (fs.existsSync(srcStylePath)) {
-      fs.copyFileSync(srcStylePath, tempStylePath);
+      try {
+        // Compile SCSS to CSS
+        const result = sass.compile(srcStylePath);
+
+        // Write the compiled CSS to the tmp directory
+        fs.writeFileSync(tempStylePath, result.css);
+        console.log('SCSS compiled successfully');
+      } catch (sassError) {
+        console.error('Error compiling SCSS:', sassError);
+        // If SCSS compilation fails, fall back to copying the file
+        fs.copyFileSync(srcStylePath, tempStylePath);
+      }
     }
 
     // Copy renderer.js to temp directory
@@ -59,7 +71,6 @@ const createWindow = () => {
 
     // Write HTML to temp directory
     const tempHtmlPath = path.join(tempDir, 'index.html');
-    console.log('HTML Path:', tempHtmlPath);
     fs.writeFileSync(tempHtmlPath, html);
 
     // Load the HTML from temp directory


### PR DESCRIPTION
This pull request includes enhancements to the `src/main.ts` file to add support for compiling SCSS to CSS and improve error handling.

Enhancements to SCSS compilation:

* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR6): Added `sass` import to support SCSS compilation.
* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR43-R55): Updated `createWindow` function to compile SCSS to CSS and write the compiled CSS to the temporary directory, including error handling for compilation failures.

Code cleanup:

* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL62): Removed unnecessary console log statement for the HTML path.